### PR TITLE
Add sync command for Git branches

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -15,6 +15,8 @@ func Execute(app *commands.App) {
 
 	root := commandsrepository.NewRootCommand()
 	rootCmd := root.ToCobraCommand(app)
+	rootCmd.SetOut(app.Terminal)
+	rootCmd.SetErr(app.Terminal)
 
 	// Cria o registro de comandos
 	registry := commands.NewRegistry()

--- a/internal/commands_repository/git/git.go
+++ b/internal/commands_repository/git/git.go
@@ -13,6 +13,7 @@ func NewGitCommand() *commands.Command {
 		SubCommands: []*commands.Command{
 			newGitNewCommand(),
 			newGitUndoCommand(),
+			newGitSyncCommand(),
 		},
 		Translations: intl.Translations{
 			"en": {

--- a/internal/commands_repository/git/sync.go
+++ b/internal/commands_repository/git/sync.go
@@ -15,22 +15,37 @@ func newGitSyncCommand() *commands.Command {
 		ShortDescriptionKey: "git.sync.short_description",
 		Translations: intl.Translations{
 			"en": {
-				"git.sync.short_description":          "Sync the current branch with the main branch",
-				"command.git.sync.syncing":            "Syncing branch {{currentBranch}} with {{mainBranch}}",
-				"command.git.sync.success":            "Branch {{currentBranch}} successfully synced with {{mainBranch}} branch",
-				"command.git.sync.already_up_to_date": "Current branch is already up to date with main branch",
+				"git.sync.short_description":                      "Sync the current branch with the main branch",
+				"command.git.sync.syncing":                        "Syncing branch {{currentBranch}} with {{mainBranch}}",
+				"command.git.sync.success":                        "Branch {{currentBranch}} successfully synced with {{mainBranch}} branch",
+				"command.git.sync.already_up_to_date":             "Current branch is already up to date with main branch",
+				"command.git.sync.failed_get_current_branch":      "Failed to get current branch",
+				"command.git.sync.failed_detect_main_branch":      "Failed to detect main branch",
+				"command.git.sync.failed_checkout_main_branch":    "Failed to checkout main branch",
+				"command.git.sync.failed_checkout_current_branch": "Failed to checkout current branch",
+				"command.git.sync.failed_rebase_current_branch":   "Failed to rebase current branch",
+				"command.git.sync.failed_check_new_commits":       "Failed to check if current branch has new commits compared to main branch",
+				"command.git.sync.failed_pull_main_branch":        "Failed to pull latest changes on main branch",
 			},
 			"pt-BR": {
-				"git.sync.short_description":          "Sincroniza a branch atual com a branch principal",
-				"command.git.sync.syncing":            "Sincronizando branch {{currentBranch}} com {{mainBranch}}",
-				"command.git.sync.success":            "Branch {{currentBranch}} sincronizada com a branch {{mainBranch}} com sucesso",
-				"command.git.sync.already_up_to_date": "A branch atual já está atualizada com a branch principal",
+				"git.sync.short_description":                      "Sincroniza a branch atual com a branch principal",
+				"command.git.sync.syncing":                        "Sincronizando branch {{currentBranch}} com {{mainBranch}}",
+				"command.git.sync.success":                        "Branch {{currentBranch}} sincronizada com a branch {{mainBranch}} com sucesso",
+				"command.git.sync.already_up_to_date":             "A branch atual já está atualizada com a branch principal",
+				"command.git.sync.failed_get_current_branch":      "Falha ao obter a branch atual",
+				"command.git.sync.failed_detect_main_branch":      "Falha ao detectar a branch principal",
+				"command.git.sync.failed_checkout_main_branch":    "Falha ao fazer checkout da branch principal",
+				"command.git.sync.failed_checkout_current_branch": "Falha ao fazer checkout da branch atual",
+				"command.git.sync.failed_rebase_current_branch":   "Falha ao rebasear a branch atual",
+				"command.git.sync.failed_check_new_commits":       "Falha ao verificar se a branch atual tem novos commits",
+				"command.git.sync.failed_pull_main_branch":        "Falha ao puxar as últimas mudanças da branch principal",
 			},
 		},
 		Handler: func(ctx context.Context, execData *commands.ExecData) error {
 			log := execData.Logger
 			term := execData.Terminal
 			t := execData.Translator.T
+			tErr := execData.Translator.Errorf
 
 			log.Info("Starting git sync process")
 			gitService := services.NewGitService().WithLogger(execData.Logger.WithGroup("gitservice"))
@@ -43,13 +58,13 @@ func newGitSyncCommand() *commands.Command {
 			currentBranch, err := gitService.GetCurrentBranch()
 			if err != nil {
 				execData.Logger.Error("Failed to get current branch", "error", err)
-				return err
+				return tErr("command.git.sync.failed_get_current_branch", map[string]string{})
 			}
 
 			mainBranch, err := gitService.DetectMainBranch()
 			if err != nil {
 				execData.Logger.Error("Failed to detect main branch", "error", err)
-				return err
+				return tErr("command.git.sync.failed_detect_main_branch", map[string]string{})
 			}
 
 			term.UpdateSpinnerMessage("sync", t("command.git.sync.syncing", map[string]string{
@@ -67,27 +82,27 @@ func newGitSyncCommand() *commands.Command {
 			err = gitService.Checkout(mainBranch)
 			if err != nil {
 				execData.Logger.Error("Failed to checkout main branch", "branch", mainBranch, "error", err.Error())
-				return err
+				return tErr("command.git.sync.failed_checkout_main_branch", map[string]string{})
 			}
 
 			term.Println(ui.Lambdaf("git pull"))
 			err = gitService.Pull()
 			if err != nil {
 				execData.Logger.Error("Failed to pull latest changes on main branch", "branch", mainBranch, "error", err.Error())
-				return err
+				return tErr("command.git.sync.failed_pull_main_branch", map[string]string{})
 			}
 
 			term.Println(ui.Lambdaf("git checkout %s", currentBranch))
 			err = gitService.Checkout(currentBranch)
 			if err != nil {
 				execData.Logger.Error("Failed to checkout back to current branch", "branch", currentBranch, "error", err.Error())
-				return err
+				return tErr("command.git.sync.failed_checkout_current_branch", map[string]string{})
 			}
 
 			hasNewCommits, err := gitService.BranchHasNewCommitsFor(mainBranch)
 			if err != nil {
 				execData.Logger.Error("Failed to check if current branch has new commits compared to main branch", "branch", currentBranch, "mainBranch", mainBranch, "error", err.Error())
-				return err
+				return tErr("command.git.sync.failed_check_new_commits", map[string]string{})
 			}
 
 			if !hasNewCommits {
@@ -107,7 +122,7 @@ func newGitSyncCommand() *commands.Command {
 			err = gitService.Rebase(mainBranch)
 			if err != nil {
 				execData.Logger.Error("Failed to rebase current branch with main branch", "branch", currentBranch, "mainBranch", mainBranch, "error", err.Error())
-				return err
+				return tErr("command.git.sync.failed_rebase_current_branch", map[string]string{})
 			}
 
 			term.StopSpinner("sync", t("command.git.sync.success", map[string]string{

--- a/internal/commands_repository/git/sync.go
+++ b/internal/commands_repository/git/sync.go
@@ -1,0 +1,122 @@
+package gitcmd
+
+import (
+	"context"
+
+	"github.com/maycon-jesus/mj-cli/internal/commands"
+	"github.com/maycon-jesus/mj-cli/internal/services"
+	"github.com/maycon-jesus/mj-cli/pkg/intl"
+	"github.com/maycon-jesus/mj-cli/pkg/ui"
+)
+
+func newGitSyncCommand() *commands.Command {
+	return &commands.Command{
+		Name:                "sync",
+		ShortDescriptionKey: "git.sync.short_description",
+		Translations: intl.Translations{
+			"en": {
+				"git.sync.short_description":          "Sync the current branch with the main branch",
+				"command.git.sync.syncing":            "Syncing branch {{currentBranch}} with {{mainBranch}}",
+				"command.git.sync.success":            "Branch {{currentBranch}} successfully synced with {{mainBranch}} branch",
+				"command.git.sync.already_up_to_date": "Current branch is already up to date with main branch",
+			},
+			"pt-BR": {
+				"git.sync.short_description":          "Sincroniza a branch atual com a branch principal",
+				"command.git.sync.syncing":            "Sincronizando branch {{currentBranch}} com {{mainBranch}}",
+				"command.git.sync.success":            "Branch {{currentBranch}} sincronizada com a branch {{mainBranch}} com sucesso",
+				"command.git.sync.already_up_to_date": "A branch atual já está atualizada com a branch principal",
+			},
+		},
+		Handler: func(ctx context.Context, execData *commands.ExecData) error {
+			log := execData.Logger
+			term := execData.Terminal
+			t := execData.Translator.T
+
+			log.Info("Starting git sync process")
+			gitService := services.NewGitService().WithLogger(execData.Logger.WithGroup("gitservice"))
+
+			term.StartSpinner("sync", t("command.git.sync.syncing", map[string]string{
+				"currentBranch": "...",
+				"mainBranch":    "...",
+			}))
+
+			currentBranch, err := gitService.GetCurrentBranch()
+			if err != nil {
+				execData.Logger.Error("Failed to get current branch", "error", err)
+				return err
+			}
+
+			mainBranch, err := gitService.DetectMainBranch()
+			if err != nil {
+				execData.Logger.Error("Failed to detect main branch", "error", err)
+				return err
+			}
+
+			term.UpdateSpinnerMessage("sync", t("command.git.sync.syncing", map[string]string{
+				"currentBranch": currentBranch,
+				"mainBranch":    mainBranch,
+			}))
+
+			term.Println(ui.Title(t("command.git.sync.syncing", map[string]string{
+				"currentBranch": currentBranch,
+				"mainBranch":    mainBranch,
+			})))
+			execData.Logger.Info("Syncing current branch with main branch", "mainBranch", mainBranch, "currentBranch", currentBranch)
+
+			term.Println(ui.Lambdaf("git checkout %s", mainBranch))
+			err = gitService.Checkout(mainBranch)
+			if err != nil {
+				execData.Logger.Error("Failed to checkout main branch", "branch", mainBranch, "error", err.Error())
+				return err
+			}
+
+			term.Println(ui.Lambdaf("git pull"))
+			err = gitService.Pull()
+			if err != nil {
+				execData.Logger.Error("Failed to pull latest changes on main branch", "branch", mainBranch, "error", err.Error())
+				return err
+			}
+
+			term.Println(ui.Lambdaf("git checkout %s", currentBranch))
+			err = gitService.Checkout(currentBranch)
+			if err != nil {
+				execData.Logger.Error("Failed to checkout back to current branch", "branch", currentBranch, "error", err.Error())
+				return err
+			}
+
+			hasNewCommits, err := gitService.BranchHasNewCommitsFor(mainBranch)
+			if err != nil {
+				execData.Logger.Error("Failed to check if current branch has new commits compared to main branch", "branch", currentBranch, "mainBranch", mainBranch, "error", err.Error())
+				return err
+			}
+
+			if !hasNewCommits {
+				execData.Logger.Info("Current branch is already up to date with main branch", "branch", currentBranch, "mainBranch", mainBranch)
+				term.Println(ui.Info(t("command.git.sync.already_up_to_date", map[string]string{
+					"currentBranch": currentBranch,
+					"mainBranch":    mainBranch,
+				})))
+				term.StopSpinner("sync", t("command.git.sync.success", map[string]string{
+					"currentBranch": currentBranch,
+					"mainBranch":    mainBranch,
+				}))
+				return nil
+			}
+
+			term.Println(ui.Lambdaf("git rebase %s", mainBranch))
+			err = gitService.Rebase(mainBranch)
+			if err != nil {
+				execData.Logger.Error("Failed to rebase current branch with main branch", "branch", currentBranch, "mainBranch", mainBranch, "error", err.Error())
+				return err
+			}
+
+			term.StopSpinner("sync", t("command.git.sync.success", map[string]string{
+				"currentBranch": currentBranch,
+				"mainBranch":    mainBranch,
+			}))
+			execData.Logger.Info("Current branch synced with main branch successfully")
+
+			return nil
+		},
+	}
+}

--- a/internal/commands_repository/git/sync.go
+++ b/internal/commands_repository/git/sync.go
@@ -58,12 +58,14 @@ func newGitSyncCommand() *commands.Command {
 			currentBranch, err := gitService.GetCurrentBranch()
 			if err != nil {
 				execData.Logger.Error("Failed to get current branch", "error", err)
+				term.StopSpinnerWithError("sync", t("command.git.sync.failed_get_current_branch", map[string]string{}))
 				return tErr("command.git.sync.failed_get_current_branch", map[string]string{})
 			}
 
 			mainBranch, err := gitService.DetectMainBranch()
 			if err != nil {
 				execData.Logger.Error("Failed to detect main branch", "error", err)
+				term.StopSpinnerWithError("sync", t("command.git.sync.failed_detect_main_branch", map[string]string{}))
 				return tErr("command.git.sync.failed_detect_main_branch", map[string]string{})
 			}
 
@@ -82,6 +84,7 @@ func newGitSyncCommand() *commands.Command {
 			err = gitService.Checkout(mainBranch)
 			if err != nil {
 				execData.Logger.Error("Failed to checkout main branch", "branch", mainBranch, "error", err.Error())
+				term.StopSpinnerWithError("sync", t("command.git.sync.failed_checkout_main_branch", map[string]string{}))
 				return tErr("command.git.sync.failed_checkout_main_branch", map[string]string{})
 			}
 
@@ -89,6 +92,7 @@ func newGitSyncCommand() *commands.Command {
 			err = gitService.Pull()
 			if err != nil {
 				execData.Logger.Error("Failed to pull latest changes on main branch", "branch", mainBranch, "error", err.Error())
+				term.StopSpinnerWithError("sync", t("command.git.sync.failed_pull_main_branch", map[string]string{}))
 				return tErr("command.git.sync.failed_pull_main_branch", map[string]string{})
 			}
 
@@ -96,12 +100,14 @@ func newGitSyncCommand() *commands.Command {
 			err = gitService.Checkout(currentBranch)
 			if err != nil {
 				execData.Logger.Error("Failed to checkout back to current branch", "branch", currentBranch, "error", err.Error())
+				term.StopSpinnerWithError("sync", t("command.git.sync.failed_checkout_current_branch", map[string]string{}))
 				return tErr("command.git.sync.failed_checkout_current_branch", map[string]string{})
 			}
 
 			hasNewCommits, err := gitService.BranchHasNewCommitsFor(mainBranch)
 			if err != nil {
 				execData.Logger.Error("Failed to check if current branch has new commits compared to main branch", "branch", currentBranch, "mainBranch", mainBranch, "error", err.Error())
+				term.StopSpinnerWithError("sync", t("command.git.sync.failed_check_new_commits", map[string]string{}))
 				return tErr("command.git.sync.failed_check_new_commits", map[string]string{})
 			}
 
@@ -122,6 +128,7 @@ func newGitSyncCommand() *commands.Command {
 			err = gitService.Rebase(mainBranch)
 			if err != nil {
 				execData.Logger.Error("Failed to rebase current branch with main branch", "branch", currentBranch, "mainBranch", mainBranch, "error", err.Error())
+				term.StopSpinnerWithError("sync", t("command.git.sync.failed_rebase_current_branch", map[string]string{}))
 				return tErr("command.git.sync.failed_rebase_current_branch", map[string]string{})
 			}
 

--- a/internal/services/git.go
+++ b/internal/services/git.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"strings"
 
 	"github.com/maycon-jesus/mj-cli/pkg/cmd"
 )
@@ -113,4 +114,40 @@ func (s *GitService) UndoLastCommit() error {
 	}
 	s.logger.Debug("Last commit undone successfully")
 	return nil
+}
+
+func (s *GitService) GetCurrentBranch() (string, error) {
+	s.logger.Debug("Getting current branch")
+	output, err := cmd.GetCommandOutput("git branch --show-current")
+	if err != nil {
+		s.logger.Debug("Failed to get current branch", "error", err)
+		return "", err
+	}
+	currentBranch := strings.TrimSpace(string(output))
+	s.logger.Debug("Current branch retrieved successfully", "branch", currentBranch)
+	return currentBranch, nil
+}
+
+func (s *GitService) Rebase(baseBranch string) error {
+	s.logger.Debug("Rebasing current branch onto base branch", "baseBranch", baseBranch)
+	output, err := cmd.GetCommandOutput(fmt.Sprintf("git rebase %s", baseBranch))
+	if err != nil {
+		s.logger.Debug("Failed to rebase", "baseBranch", baseBranch, "error", err, "output", output)
+		return err
+	}
+	s.logger.Debug("Rebase completed successfully", "baseBranch", baseBranch)
+	return nil
+}
+
+func (s *GitService) BranchHasNewCommitsFor(baseBranch string) (bool, error) {
+	s.logger.Debug("Checking if base branch has new commits not in HEAD", "baseBranch", baseBranch)
+	output, err := cmd.GetCommandOutput(fmt.Sprintf("git rev-list --right-only --count HEAD...%s", baseBranch))
+	if err != nil {
+		s.logger.Debug("Failed to check for new commits", "baseBranch", baseBranch, "error", err, "output", output)
+		return false, err
+	}
+	countStr := strings.TrimSpace(output)
+	hasNewCommits := countStr != "0"
+	s.logger.Debug("Checked for new commits successfully", "baseBranch", baseBranch, "hasNewCommits", hasNewCommits)
+	return hasNewCommits, nil
 }

--- a/pkg/mjterm/event.go
+++ b/pkg/mjterm/event.go
@@ -42,6 +42,11 @@ type stopSpinnerMsg struct {
 	err     bool
 }
 
+type updateSpinnerMsg struct {
+	id      string
+	message string
+}
+
 type closeMsg struct {
 	closed chan struct{}
 }

--- a/pkg/mjterm/mjterm.go
+++ b/pkg/mjterm/mjterm.go
@@ -114,6 +114,10 @@ func New() *Terminal {
 					finalMsg = fmt.Sprintf("\r\033[K\033[32m✓\033[0m %s\n", e.message)
 				}
 				fmt.Print(finalMsg)
+			case updateSpinnerMsg:
+				if term.spinner != nil && term.spinner.id == e.id {
+					term.spinner.message = e.message
+				}
 			case closeMsg:
 				if term.spinner != nil {
 					close(term.spinner.stop)

--- a/pkg/mjterm/spinner.go
+++ b/pkg/mjterm/spinner.go
@@ -22,3 +22,10 @@ func (t *Terminal) StopSpinnerWithError(id string, message string) error {
 		err:     true,
 	})
 }
+
+func (t *Terminal) UpdateSpinnerMessage(id string, message string) error {
+	return t.addEvent(updateSpinnerMsg{
+		id:      id,
+		message: message,
+	})
+}

--- a/pkg/ui/basic.go
+++ b/pkg/ui/basic.go
@@ -68,3 +68,12 @@ func Lambda(message string) string {
 		Foreground(tint.Magenta).
 		Render(str)
 }
+
+// Lambdaf é a versão formatada de Lambda que aceita formatação de string com argumentos, similar a fmt.Sprintf.
+func Lambdaf(message string, args ...any) string {
+	str := fmt.Sprintf("λ "+message, args...)
+	return tint.NewStyle().
+		Bold().
+		Foreground(tint.Magenta).
+		Render(str)
+}


### PR DESCRIPTION
Implement a new 'sync' command to synchronize the current branch with the main branch, including error handling and user feedback through spinner messages. Additional functions for branch management and message formatting have been introduced. Fixes related to command output configuration and error messaging have also been addressed.