### PR TITLE
Add uncommitted changes check and rebase abort support

### DIFF
--- a/internal/commands_repository/git/sync.go
+++ b/internal/commands_repository/git/sync.go
@@ -15,30 +15,38 @@ func newGitSyncCommand() *commands.Command {
 		ShortDescriptionKey: "git.sync.short_description",
 		Translations: intl.Translations{
 			"en": {
-				"git.sync.short_description":                      "Sync the current branch with the main branch",
-				"command.git.sync.syncing":                        "Syncing branch {{currentBranch}} with {{mainBranch}}",
-				"command.git.sync.success":                        "Branch {{currentBranch}} successfully synced with {{mainBranch}} branch",
-				"command.git.sync.already_up_to_date":             "Current branch is already up to date with main branch",
-				"command.git.sync.failed_get_current_branch":      "Failed to get current branch",
-				"command.git.sync.failed_detect_main_branch":      "Failed to detect main branch",
-				"command.git.sync.failed_checkout_main_branch":    "Failed to checkout main branch",
-				"command.git.sync.failed_checkout_current_branch": "Failed to checkout current branch",
-				"command.git.sync.failed_rebase_current_branch":   "Failed to rebase current branch",
-				"command.git.sync.failed_check_new_commits":       "Failed to check if current branch has new commits compared to main branch",
-				"command.git.sync.failed_pull_main_branch":        "Failed to pull latest changes on main branch",
+				"git.sync.short_description":                        "Sync the current branch with the main branch",
+				"command.git.sync.syncing":                          "Syncing branch {{currentBranch}} with {{mainBranch}}",
+				"command.git.sync.success":                          "Branch {{currentBranch}} successfully synced with {{mainBranch}} branch",
+				"command.git.sync.already_up_to_date":               "Current branch is already up to date with main branch",
+				"command.git.sync.failed_get_current_branch":        "Failed to get current branch",
+				"command.git.sync.failed_detect_main_branch":        "Failed to detect main branch",
+				"command.git.sync.failed_checkout_main_branch":      "Failed to checkout main branch",
+				"command.git.sync.failed_checkout_current_branch":   "Failed to checkout current branch",
+				"command.git.sync.failed_rebase_current_branch":     "Failed to rebase current branch",
+				"command.git.sync.failed_check_new_commits":         "Failed to check if current branch has new commits compared to main branch",
+				"command.git.sync.failed_pull_main_branch":          "Failed to pull latest changes on main branch",
+				"command.git.sync.stash_message":                    "mj-cli: git sync stash",
+				"command.git.sync.failed_stash_changes":             "Failed to stash changes before syncing branches",
+				"command.git.sync.failed_pop_stash_changes":         "Failed to unstash changes after syncing branches",
+				"command.git.sync.failed_check_uncommitted_changes": "Failed to check for uncommitted changes",
 			},
 			"pt-BR": {
-				"git.sync.short_description":                      "Sincroniza a branch atual com a branch principal",
-				"command.git.sync.syncing":                        "Sincronizando branch {{currentBranch}} com {{mainBranch}}",
-				"command.git.sync.success":                        "Branch {{currentBranch}} sincronizada com a branch {{mainBranch}} com sucesso",
-				"command.git.sync.already_up_to_date":             "A branch atual já está atualizada com a branch principal",
-				"command.git.sync.failed_get_current_branch":      "Falha ao obter a branch atual",
-				"command.git.sync.failed_detect_main_branch":      "Falha ao detectar a branch principal",
-				"command.git.sync.failed_checkout_main_branch":    "Falha ao fazer checkout da branch principal",
-				"command.git.sync.failed_checkout_current_branch": "Falha ao fazer checkout da branch atual",
-				"command.git.sync.failed_rebase_current_branch":   "Falha ao rebasear a branch atual",
-				"command.git.sync.failed_check_new_commits":       "Falha ao verificar se a branch atual tem novos commits",
-				"command.git.sync.failed_pull_main_branch":        "Falha ao puxar as últimas mudanças da branch principal",
+				"git.sync.short_description":                        "Sincroniza a branch atual com a branch principal",
+				"command.git.sync.syncing":                          "Sincronizando branch {{currentBranch}} com {{mainBranch}}",
+				"command.git.sync.success":                          "Branch {{currentBranch}} sincronizada com a branch {{mainBranch}} com sucesso",
+				"command.git.sync.already_up_to_date":               "A branch atual já está atualizada com a branch principal",
+				"command.git.sync.failed_get_current_branch":        "Falha ao obter a branch atual",
+				"command.git.sync.failed_detect_main_branch":        "Falha ao detectar a branch principal",
+				"command.git.sync.failed_checkout_main_branch":      "Falha ao fazer checkout da branch principal",
+				"command.git.sync.failed_checkout_current_branch":   "Falha ao fazer checkout da branch atual",
+				"command.git.sync.failed_rebase_current_branch":     "Falha ao rebasear a branch atual",
+				"command.git.sync.failed_check_new_commits":         "Falha ao verificar se a branch atual tem novos commits",
+				"command.git.sync.failed_pull_main_branch":          "Falha ao puxar as últimas mudanças da branch principal",
+				"command.git.sync.stash_message":                    "mj-cli: stash do git sync",
+				"command.git.sync.failed_stash_changes":             "Falha ao stashear as mudanças antes de sincronizar as branches",
+				"command.git.sync.failed_pop_stash_changes":         "Falha ao unstashear as mudanças depois de sincronizar as branches",
+				"command.git.sync.failed_check_uncommitted_changes": "Falha ao verificar por mudanças não comitadas",
 			},
 		},
 		Handler: func(ctx context.Context, execData *commands.ExecData) error {
@@ -80,6 +88,26 @@ func newGitSyncCommand() *commands.Command {
 			})))
 			execData.Logger.Info("Syncing current branch with main branch", "mainBranch", mainBranch, "currentBranch", currentBranch)
 
+			// check if there are uncommitted changes
+			hasUncommittedChanges, err := gitService.HasUncommitedChanges()
+			if err != nil {
+				execData.Logger.Error("Failed to check for uncommitted changes", "error", err)
+				term.StopSpinnerWithError("sync", t("command.git.sync.failed_check_uncommitted_changes", map[string]string{}))
+				return tErr("command.git.sync.failed_check_uncommitted_changes", map[string]string{})
+			}
+
+			// stash push
+			if hasUncommittedChanges {
+				term.Println(ui.Lambdaf("git stash push -m \"%s\"", t("command.git.sync.stash_message", map[string]string{})))
+				err = gitService.StashPush(t("command.git.sync.stash_message", map[string]string{}))
+				if err != nil {
+					execData.Logger.Error("Failed to stash changes", "error", err)
+					term.StopSpinnerWithError("sync", t("command.git.sync.failed_stash_changes", map[string]string{}))
+					return tErr("command.git.sync.failed_stash_changes", map[string]string{})
+				}
+			}
+
+			// checkout on main
 			term.Println(ui.Lambdaf("git checkout %s", mainBranch))
 			err = gitService.Checkout(mainBranch)
 			if err != nil {
@@ -117,6 +145,18 @@ func newGitSyncCommand() *commands.Command {
 					"currentBranch": currentBranch,
 					"mainBranch":    mainBranch,
 				})))
+
+				// stash pop
+				if hasUncommittedChanges {
+					term.Println(ui.Lambdaf("git stash pop"))
+					err = gitService.StashPop()
+					if err != nil {
+						execData.Logger.Error("Failed to pop stashed changes", "error", err)
+						term.StopSpinnerWithError("sync", t("command.git.sync.failed_pop_stash_changes", map[string]string{}))
+						return tErr("command.git.sync.failed_pop_stash_changes", map[string]string{})
+					}
+				}
+
 				term.StopSpinner("sync", t("command.git.sync.success", map[string]string{
 					"currentBranch": currentBranch,
 					"mainBranch":    mainBranch,
@@ -130,6 +170,17 @@ func newGitSyncCommand() *commands.Command {
 				execData.Logger.Error("Failed to rebase current branch with main branch", "branch", currentBranch, "mainBranch", mainBranch, "error", err.Error())
 				term.StopSpinnerWithError("sync", t("command.git.sync.failed_rebase_current_branch", map[string]string{}))
 				return tErr("command.git.sync.failed_rebase_current_branch", map[string]string{})
+			}
+
+			// stash pop
+			if hasUncommittedChanges {
+				term.Println(ui.Lambdaf("git stash pop"))
+				err = gitService.StashPop()
+				if err != nil {
+					execData.Logger.Error("Failed to pop stashed changes", "error", err)
+					term.StopSpinnerWithError("sync", t("command.git.sync.failed_pop_stash_changes", map[string]string{}))
+					return tErr("command.git.sync.failed_pop_stash_changes", map[string]string{})
+				}
 			}
 
 			term.StopSpinner("sync", t("command.git.sync.success", map[string]string{

--- a/internal/commands_repository/git/sync.go
+++ b/internal/commands_repository/git/sync.go
@@ -30,6 +30,8 @@ func newGitSyncCommand() *commands.Command {
 				"command.git.sync.failed_stash_changes":             "Failed to stash changes before syncing branches",
 				"command.git.sync.failed_pop_stash_changes":         "Failed to unstash changes after syncing branches",
 				"command.git.sync.failed_check_uncommitted_changes": "Failed to check for uncommitted changes",
+				"command.git.sync.resolve_conflicts_hint":           "Failed rebase/merge detected. Please resolve the conflicts manually, commit the changes and then run 'git merge/rebase --continue' to continue the rebase/merge process.",
+				"command.git.sync.stash_pop_hint":                   "There are stashed changes that need to be reapplied. Please run 'git stash pop' to reapply the stashed changes.",
 			},
 			"pt-BR": {
 				"git.sync.short_description":                        "Sincroniza a branch atual com a branch principal",
@@ -47,6 +49,8 @@ func newGitSyncCommand() *commands.Command {
 				"command.git.sync.failed_stash_changes":             "Falha ao stashear as mudanças antes de sincronizar as branches",
 				"command.git.sync.failed_pop_stash_changes":         "Falha ao unstashear as mudanças depois de sincronizar as branches",
 				"command.git.sync.failed_check_uncommitted_changes": "Falha ao verificar por mudanças não comitadas",
+				"command.git.sync.resolve_conflicts_hint":           "Rebase/merge com falha detectado. Por favor, resolva os conflitos manualmente, faça o commit das mudanças e então rode 'git merge/rebase --continue' para continuar o processo de rebase/merge.",
+				"command.git.sync.stash_pop_hint":                   "Há mudanças stashed que precisam ser reaplicadas. Por favor, execute 'git stash pop' para reaplicar as mudanças stashed.",
 			},
 		},
 		Handler: func(ctx context.Context, execData *commands.ExecData) error {
@@ -57,6 +61,8 @@ func newGitSyncCommand() *commands.Command {
 
 			log.Info("Starting git sync process")
 			gitService := services.NewGitService().WithLogger(execData.Logger.WithGroup("gitservice"))
+
+			onMain, stashed := false, false
 
 			term.StartSpinner("sync", t("command.git.sync.syncing", map[string]string{
 				"currentBranch": "...",
@@ -96,6 +102,29 @@ func newGitSyncCommand() *commands.Command {
 				return tErr("command.git.sync.failed_check_uncommitted_changes", map[string]string{})
 			}
 
+			// rollback
+			defer func() {
+				if onMain {
+					err = gitService.Checkout(currentBranch)
+					if err != nil {
+						execData.Logger.Error("Failed to checkout back to current branch during rollback", "branch", currentBranch, "error", err.Error())
+						term.Println(ui.Info(t("command.git.sync.failed_checkout_current_branch", map[string]string{})))
+						if stashed {
+							term.Println(ui.Info(t("command.git.sync.stash_pop_hint", map[string]string{})))
+						}
+						return
+					}
+				}
+
+				if stashed {
+					err = unstashChanges(ctx, execData, gitService)
+					if err != nil {
+						term.Println(ui.Info(t("command.git.sync.stash_pop_hint", map[string]string{})))
+						return
+					}
+				}
+			}()
+
 			// stash push
 			if hasUncommittedChanges {
 				term.Println(ui.Lambdaf("git stash push -m \"%s\"", t("command.git.sync.stash_message", map[string]string{})))
@@ -105,6 +134,8 @@ func newGitSyncCommand() *commands.Command {
 					term.StopSpinnerWithError("sync", t("command.git.sync.failed_stash_changes", map[string]string{}))
 					return tErr("command.git.sync.failed_stash_changes", map[string]string{})
 				}
+				stashed = true
+				execData.Logger.Info("Uncommitted changes stashed successfully")
 			}
 
 			// checkout on main
@@ -115,7 +146,9 @@ func newGitSyncCommand() *commands.Command {
 				term.StopSpinnerWithError("sync", t("command.git.sync.failed_checkout_main_branch", map[string]string{}))
 				return tErr("command.git.sync.failed_checkout_main_branch", map[string]string{})
 			}
+			onMain = true
 
+			// pull on main
 			term.Println(ui.Lambdaf("git pull"))
 			err = gitService.Pull()
 			if err != nil {
@@ -124,6 +157,7 @@ func newGitSyncCommand() *commands.Command {
 				return tErr("command.git.sync.failed_pull_main_branch", map[string]string{})
 			}
 
+			// checkout back to current branch
 			term.Println(ui.Lambdaf("git checkout %s", currentBranch))
 			err = gitService.Checkout(currentBranch)
 			if err != nil {
@@ -131,7 +165,9 @@ func newGitSyncCommand() *commands.Command {
 				term.StopSpinnerWithError("sync", t("command.git.sync.failed_checkout_current_branch", map[string]string{}))
 				return tErr("command.git.sync.failed_checkout_current_branch", map[string]string{})
 			}
+			onMain = false
 
+			// check if current branch has new commits compared to main branch
 			hasNewCommits, err := gitService.BranchHasNewCommitsFor(mainBranch)
 			if err != nil {
 				execData.Logger.Error("Failed to check if current branch has new commits compared to main branch", "branch", currentBranch, "mainBranch", mainBranch, "error", err.Error())
@@ -146,14 +182,14 @@ func newGitSyncCommand() *commands.Command {
 					"mainBranch":    mainBranch,
 				})))
 
-				// stash pop
-				if hasUncommittedChanges {
-					term.Println(ui.Lambdaf("git stash pop"))
-					err = gitService.StashPop()
+				// unstash changes if there are stashed changes
+				if stashed {
+					err = unstashChanges(ctx, execData, gitService)
 					if err != nil {
-						execData.Logger.Error("Failed to pop stashed changes", "error", err)
-						term.StopSpinnerWithError("sync", t("command.git.sync.failed_pop_stash_changes", map[string]string{}))
-						return tErr("command.git.sync.failed_pop_stash_changes", map[string]string{})
+						log.Error("Failed to unstash changes after syncing with main branch", "error", err.Error())
+					} else {
+						log.Info("Stashed changes unstashed successfully")
+						stashed = false
 					}
 				}
 
@@ -164,22 +200,31 @@ func newGitSyncCommand() *commands.Command {
 				return nil
 			}
 
+			// rebase current branch with main branch
 			term.Println(ui.Lambdaf("git rebase %s", mainBranch))
 			err = gitService.Rebase(mainBranch)
 			if err != nil {
 				execData.Logger.Error("Failed to rebase current branch with main branch", "branch", currentBranch, "mainBranch", mainBranch, "error", err.Error())
+
+				// abort rebase if it failed
+				abortErr := gitService.RebaseAbort()
+				if abortErr != nil {
+					execData.Logger.Error("Failed to abort rebase after failed rebase attempt", "branch", currentBranch, "mainBranch", mainBranch, "error", abortErr.Error())
+					term.Println(ui.Info(t("command.git.sync.resolve_conflicts_hint", map[string]string{})))
+				}
+
 				term.StopSpinnerWithError("sync", t("command.git.sync.failed_rebase_current_branch", map[string]string{}))
 				return tErr("command.git.sync.failed_rebase_current_branch", map[string]string{})
 			}
 
-			// stash pop
-			if hasUncommittedChanges {
-				term.Println(ui.Lambdaf("git stash pop"))
-				err = gitService.StashPop()
+			// unstash changes if there are stashed changes
+			if stashed {
+				err = unstashChanges(ctx, execData, gitService)
 				if err != nil {
-					execData.Logger.Error("Failed to pop stashed changes", "error", err)
-					term.StopSpinnerWithError("sync", t("command.git.sync.failed_pop_stash_changes", map[string]string{}))
-					return tErr("command.git.sync.failed_pop_stash_changes", map[string]string{})
+					log.Error("Failed to unstash changes after rebasing", "error", err.Error())
+				} else {
+					execData.Logger.Info("Stashed changes unstashed successfully")
+					stashed = false
 				}
 			}
 
@@ -192,4 +237,17 @@ func newGitSyncCommand() *commands.Command {
 			return nil
 		},
 	}
+}
+
+func unstashChanges(ctx context.Context, execData *commands.ExecData, gitService *services.GitService) error {
+	term := execData.Terminal
+	tErr := execData.Translator.Errorf
+
+	term.Println(ui.Lambdaf("git stash pop"))
+	err := gitService.StashPop()
+	if err != nil {
+		execData.Logger.Error("Failed to pop stashed changes", "error", err)
+		return tErr("command.git.sync.failed_pop_stash_changes", map[string]string{})
+	}
+	return nil
 }

--- a/internal/services/git.go
+++ b/internal/services/git.go
@@ -139,6 +139,17 @@ func (s *GitService) Rebase(baseBranch string) error {
 	return nil
 }
 
+func (s *GitService) RebaseAbort() error {
+	s.logger.Debug("Aborting rebase")
+	err := cmd.RunCommandWithOptions("git rebase --abort", cmd.CommandOptions{})
+	if err != nil {
+		s.logger.Debug("Failed to abort rebase", "error", err)
+		return err
+	}
+	s.logger.Debug("Rebase aborted successfully")
+	return nil
+}
+
 func (s *GitService) BranchHasNewCommitsFor(baseBranch string) (bool, error) {
 	s.logger.Debug("Checking if base branch has new commits not in HEAD", "baseBranch", baseBranch)
 	output, err := cmd.GetCommandOutput(fmt.Sprintf("git rev-list --right-only --count HEAD...%s", baseBranch))

--- a/internal/services/git.go
+++ b/internal/services/git.go
@@ -151,3 +151,37 @@ func (s *GitService) BranchHasNewCommitsFor(baseBranch string) (bool, error) {
 	s.logger.Debug("Checked for new commits successfully", "baseBranch", baseBranch, "hasNewCommits", hasNewCommits)
 	return hasNewCommits, nil
 }
+
+func (s *GitService) HasUncommitedChanges() (bool, error) {
+	s.logger.Debug("Checking for uncommited changes")
+	output, err := cmd.GetCommandOutput("git status --porcelain")
+	if err != nil {
+		s.logger.Debug("Failed to check for uncommited changes", "error", err)
+		return false, err
+	}
+	hasChanges := strings.TrimSpace(output) != ""
+	s.logger.Debug("Checked for uncommited changes successfully", "hasUncommitedChanges", hasChanges)
+	return hasChanges, nil
+}
+
+func (s *GitService) StashPush(stashName string) error {
+	s.logger.Debug("Stashing changes", "stashName", stashName)
+	err := cmd.RunCommandWithOptions(fmt.Sprintf("git stash push -m \"%s\"", stashName), cmd.CommandOptions{})
+	if err != nil {
+		s.logger.Debug("Failed to stash changes", "stashName", stashName, "error", err)
+		return err
+	}
+	s.logger.Debug("Changes stashed successfully", "stashName", stashName)
+	return nil
+}
+
+func (s *GitService) StashPop() error {
+	s.logger.Debug("Popping latest stash")
+	err := cmd.RunCommandWithOptions("git stash pop", cmd.CommandOptions{})
+	if err != nil {
+		s.logger.Debug("Failed to pop latest stash", "error", err)
+		return err
+	}
+	s.logger.Debug("Latest stash popped successfully")
+	return nil
+}


### PR DESCRIPTION
Introduce functionality to check for uncommitted changes during synchronization and add support for aborting a rebase, enhancing error handling for conflict scenarios.